### PR TITLE
Port to Gtk4

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -17,7 +17,7 @@ charset = utf-8
 # 4 space indentation
 [*.{js,lua,css,html}]
 indent_style = tab
-indent_size  = 4
+indent_size  = 2
 #indent_style = space
 
 # Tab indentation (no size specified)

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 moonterm.geany
 /moonterm
 /moonterm.luastatic.c
+/test

--- a/README.md
+++ b/README.md
@@ -19,4 +19,4 @@ make moonterm
 - [Lua](https://www.lua.org/download.html)
 - [Lua-lgi](https://github.com/pavouk/lgi)
 - [VTE](https://github.com/GNOME/vte)
-- [Keybinder](https://github.com/kupferlauncher/keybinder/) **optional: required by quake-mode**
+

--- a/libraries/utils.lua
+++ b/libraries/utils.lua
@@ -41,40 +41,4 @@ function utils:path_name(uri)
     return result
 end
 
-function utils:print_r(t, fd)
-    fd = fd or io.stdout
-    local function print(str) str = str or "" fd:write(str.."\n") end
-    local print_r_cache={}
-    local function sub_print_r(t,indent)
-        if (print_r_cache[tostring(t)]) then
-            print(indent.."*"..tostring(t))
-        else
-            print_r_cache[tostring(t)]=true
-            if (type(t)=="table") then
-                for pos,val in pairs(t) do
-                    if (type(val)=="table") then
-                        print(indent.."["..pos.."] => "..tostring(t).." {")
-                        sub_print_r(val,indent..string.rep(" ",string.len(pos)+8))
-                        print(indent..string.rep(" ",string.len(pos)+6).."}")
-                    elseif (type(val)=="string") then
-                        print(indent.."["..pos..'] => "'..val..'"')
-                    else
-                        print(indent.."["..pos.."] => "..tostring(val))
-                    end
-                end
-            else
-                print(indent..tostring(t))
-            end
-        end
-    end
-    if (type(t)=="table") then
-        print(tostring(t).." {")
-        sub_print_r(t,"  ")
-        print("}")
-    else
-        sub_print_r(t,"  ")
-    end
-    print()
-end
-
 return utils

--- a/moonterm.lua
+++ b/moonterm.lua
@@ -12,7 +12,7 @@ shell 			= os.getenv("SHELL") or "/bin/sh"
 inifile			= require("libraries.LIP")
 utils				= require("libraries.utils")
 
-local lgi					= require("lgi")
+local lgi		= require("lgi")
 Gtk					= lgi.require('Gtk', '4.0')
 Gdk					= lgi.require('Gdk', '4.0')
 Vte					= lgi.require('Vte', '3.91')
@@ -33,7 +33,7 @@ end
 -- MoonTerm
 require('src.moonterm-app')
 -- require('src.moonterm-menu')
--- require('src.moonterm-dialog')
+require('src.moonterm-dialog')
 -- require('src.moonterm-keybinds')
 
 app:run()

--- a/moonterm.lua
+++ b/moonterm.lua
@@ -34,6 +34,6 @@ conf				= inifile:load(('%s/moonterm.ini'):format(dir))
 require('src.moonterm-app')
 require('src.moonterm-menu')
 require('src.moonterm-dialog')
--- require('src.moonterm-keybinds')
+require('src.moonterm-keybinds')
 
 app:run()

--- a/moonterm.lua
+++ b/moonterm.lua
@@ -8,17 +8,18 @@
  @date      16.01.2021 23:52:45 -04
 --]]
 
-shell 				= os.getenv("SHELL") or "/bin/sh"
-inifile				= require("libraries.LIP")
+shell 			= os.getenv("SHELL") or "/bin/sh"
+inifile			= require("libraries.LIP")
 utils				= require("libraries.utils")
 
-lgi					= require("lgi")
-Gtk					= lgi.require('Gtk', '3.0')
-Gdk					= lgi.require('Gdk', '3.0')
-Vte					= lgi.require('Vte', '2.91')
+local lgi					= require("lgi")
+Gtk					= lgi.require('Gtk', '4.0')
+Gdk					= lgi.require('Gdk', '4.0')
+Vte					= lgi.require('Vte', '3.91')
 GLib				= lgi.require('GLib', '2.0')
+Gio					= lgi.require('Gio', '2.0')
 
-app					= Gtk.Application()
+app 				= Gtk.Application.new("com.github.sodomon2.moonterm", Gio.ApplicationFlags.DEFAULT_FLAGS)
 term				= Vte.Terminal()
 
 utils:create_config('moonterm','moonterm.ini')
@@ -26,13 +27,13 @@ dir 				= ('%s/moonterm'):format(GLib.get_user_config_dir())
 conf				= inifile:load(('%s/moonterm.ini'):format(dir))
 
 if conf.moonterm.quake_mode == true then
-	Keybinder 		= lgi.require('Keybinder', '3.0')
+	Keybinder = lgi.require('Keybinder', '3.0')
 end
 
 -- MoonTerm
 require('src.moonterm-app')
-require('src.moonterm-menu')
-require('src.moonterm-dialog')
-require('src.moonterm-keybinds')
+-- require('src.moonterm-menu')
+-- require('src.moonterm-dialog')
+-- require('src.moonterm-keybinds')
 
 app:run()

--- a/moonterm.lua
+++ b/moonterm.lua
@@ -4,7 +4,7 @@
  @package   MoonTerm
  @filename  moonterm.lua
  @version   1.0
- @author    Diaz Urbaneja Victor Diego Alejandro <sodomon2@gmail.com>
+ @author    Diaz Urbaneja Victor Diego Alejandro <sodomon.dev@gmail.com>
  @date      16.01.2021 23:52:45 -04
 --]]
 
@@ -32,7 +32,7 @@ end
 
 -- MoonTerm
 require('src.moonterm-app')
--- require('src.moonterm-menu')
+require('src.moonterm-menu')
 require('src.moonterm-dialog')
 -- require('src.moonterm-keybinds')
 

--- a/moonterm.lua
+++ b/moonterm.lua
@@ -26,9 +26,9 @@ utils:create_config('moonterm','moonterm.ini')
 dir 				= ('%s/moonterm'):format(GLib.get_user_config_dir())
 conf				= inifile:load(('%s/moonterm.ini'):format(dir))
 
-if conf.moonterm.quake_mode == true then
-	Keybinder = lgi.require('Keybinder', '3.0')
-end
+-- if conf.moonterm.quake_mode == true then
+-- 	Keybinder = lgi.require('Keybinder', '3.0')
+-- end
 
 -- MoonTerm
 require('src.moonterm-app')

--- a/src/moonterm-app.lua
+++ b/src/moonterm-app.lua
@@ -21,8 +21,8 @@ function term:on_child_exited()
 	app:quit()
 end
 
+main_window = Gtk.Window()
 function app:on_activate()
-	local main_window = Gtk.ApplicationWindow.new(self)
 	local scroll = Gtk.ScrolledWindow()
 
 	local headerbar    = Gtk.HeaderBar()
@@ -49,7 +49,7 @@ function app:on_activate()
 		function() end
 	)
 	-- dialog_config.child.entry_interpreter.text = conf.moonterm.interpreter
-	-- if arg[1] then term:feed_child_binary(arg[1] .. "\n") end
+	if arg[1] then term:feed_child_binary(arg[1] .. "\n") end
 	-- if conf.moonterm.quake_mode == true then
 	-- 	main_window.decorated = false
 	-- 	main_window:resize(Gdk.Screen.width(), Gdk.Screen.height()*(50/100))
@@ -59,5 +59,6 @@ function app:on_activate()
 end
 
 function app:on_activate()
-	self.active_window:present()
+	self:add_window(main_window)
+	main_window:present()
 end

--- a/src/moonterm-app.lua
+++ b/src/moonterm-app.lua
@@ -51,12 +51,15 @@ function app:on_activate()
 	)
 	entry_interpreter.text = conf.moonterm.interpreter
 	if arg[1] then term:feed_child_binary(arg[1] .. "\n") end
+
+
 	-- if conf.moonterm.quake_mode == true then
 	-- 	main_window.decorated = false
 	-- 	main_window:resize(Gdk.Screen.width(), Gdk.Screen.height()*(50/100))
 	-- 	main_window:set_position(0)
 	-- 	-- Keybinder.init()
 	-- end
+	
 end
 
 function app:on_activate()

--- a/src/moonterm-app.lua
+++ b/src/moonterm-app.lua
@@ -2,10 +2,11 @@
  @package   MoonTerm
  @filename  moonterm-app.lua
  @version   1.0
- @author    Diaz Urbaneja Victor Diego Alejandro <sodomon2@gmail.com>
+ @author    Diaz Urbaneja Victor Diego Alejandro <sodomon.dev@gmail.com>
  @date      22.01.2021 01:34:58 -04
 --]]
 
+main_window = Gtk.Window()
 about_window  = Gtk.AboutDialog ({
 	program_name   = 'Moonterm',
 	version        = '4.0',
@@ -14,14 +15,14 @@ about_window  = Gtk.AboutDialog ({
 	website   	   = 'https://github.com/moonsteal/moonterm',
 	website_label  = 'Github',
 	logo_icon_name = 'Terminal',
-	authors 	     = {'Díaz Urbaneja Víctor Diego Alejandro'}
+	authors 	     = {'Díaz Urbaneja Víctor Diego Alejandro'},
+	hide_on_close  = true
 })
 
 function term:on_child_exited()
 	app:quit()
 end
 
-main_window = Gtk.Window()
 function app:on_activate()
 	local scroll = Gtk.ScrolledWindow()
 
@@ -48,7 +49,7 @@ function app:on_activate()
 		GLib.SpawnFlags.DEFAULT,
 		function() end
 	)
-	-- dialog_config.child.entry_interpreter.text = conf.moonterm.interpreter
+	entry_interpreter.text = conf.moonterm.interpreter
 	if arg[1] then term:feed_child_binary(arg[1] .. "\n") end
 	-- if conf.moonterm.quake_mode == true then
 	-- 	main_window.decorated = false

--- a/src/moonterm-app.lua
+++ b/src/moonterm-app.lua
@@ -8,43 +8,37 @@
 
 about_window  = Gtk.AboutDialog ({
 	program_name   = 'Moonterm',
-	version        = '3.0',
-	copyright      = 'Díaz Urbaneja Víctor Diego Alejandro\n Copyright © 2021-2022',
+	version        = '4.0',
+	copyright      = 'Díaz Urbaneja Víctor Diego Alejandro\n Copyright © 2021-2025',
 	comments  	   = 'a minimalist and customizable terminal in lua',
 	website   	   = 'https://github.com/moonsteal/moonterm',
 	website_label  = 'Github',
 	logo_icon_name = 'Terminal',
-	authors 	   = {'Díaz Urbaneja Víctor Diego Alejandro'}
+	authors 	     = {'Díaz Urbaneja Víctor Diego Alejandro'}
 })
-
-main_window	= Gtk.Window {
-	width_request	= 600,
-	height_request	= 400,
-	Gtk.ScrolledWindow{id = 'scroll'}
-}
-
-headerbar    = Gtk.HeaderBar {
-	title 	 = 'MoonTerm',
-	subtitle = 'a minimalist and customizable terminal in lua',
-	show_close_button = true
-}
-
-interpreter = utils:path_name(conf.moonterm.interpreter)['name']
-if conf.moonterm.interpreter == shell then
-	headerbar.title = 'Moonterm'
-else
-	headerbar.title = ('Moonterm - %s'):format(interpreter)
-	headerbar.subtitle = ('Moonterm using : %s interpreter'):format(interpreter)
-end
 
 function term:on_child_exited()
 	app:quit()
 end
 
 function app:on_activate()
+	local main_window = Gtk.ApplicationWindow.new(self)
+	local scroll = Gtk.ScrolledWindow()
+
+	local headerbar    = Gtk.HeaderBar()
+
+	main_window.child = scroll
+	main_window.title = 'MoonTerm'
+
+	scroll:set_child(term)
+	main_window:set_titlebar(headerbar)
+	main_window:set_default_size(600, 400)
+	headerbar.show_title_buttons = true
+	main_window:set_icon_name('terminal')
+
 	font = term:get_font()
 	--font:set_family("Camingo Code") -- Fix error when " Camingo Code " font is not available
-	font:set_size(font:get_size() * 1.1)
+	--font:set_size(font:get_size() * 1.1)
 
 	term:spawn_sync(
 		Vte.PtyFlags.DEFAULT,
@@ -53,20 +47,17 @@ function app:on_activate()
 		nil,
 		GLib.SpawnFlags.DEFAULT,
 		function() end
-    )
-	dialog_config.child.entry_interpreter.text = conf.moonterm.interpreter
-	main_window:set_titlebar(headerbar)
-	main_window.child.scroll:add(term)
-	main_window:set_icon_name('terminal')
-	if arg[1] then term:feed_child_binary(arg[1] .. "\n") end
-	if conf.moonterm.quake_mode == true then
-		main_window.decorated = false
-		main_window:resize(Gdk.Screen.width(), Gdk.Screen.height()*(50/100))
-		main_window:set_position(0)
-		Keybinder.init()
-	else
-		main_window:show_all()
-	end
-	self:add_window(main_window)
+	)
+	-- dialog_config.child.entry_interpreter.text = conf.moonterm.interpreter
+	-- if arg[1] then term:feed_child_binary(arg[1] .. "\n") end
+	-- if conf.moonterm.quake_mode == true then
+	-- 	main_window.decorated = false
+	-- 	main_window:resize(Gdk.Screen.width(), Gdk.Screen.height()*(50/100))
+	-- 	main_window:set_position(0)
+	-- 	-- Keybinder.init()
+	-- end
 end
 
+function app:on_activate()
+	self.active_window:present()
+end

--- a/src/moonterm-dialog.lua
+++ b/src/moonterm-dialog.lua
@@ -13,7 +13,7 @@ dialog_config = Gtk.Dialog {
 }
 
 entry_interpreter = Gtk.Entry()
-quake_switch = Gtk.Switch()
+-- quake_switch = Gtk.Switch()
 
 content = Gtk.Box {
 	orientation = 'VERTICAL',
@@ -26,14 +26,16 @@ content = Gtk.Box {
 		},
 		entry_interpreter
 	},
-	Gtk.Box {
-		orientation = 'HORIZONTAL',
-		spacing = 5,
-		Gtk.Label {
-			label = " Quake Mode : "
-		},
-		quake_switch
-	},
+
+	-- Gtk.Box {
+	-- 	orientation = 'HORIZONTAL',
+	-- 	spacing = 5,
+	-- 	Gtk.Label {
+	-- 		label = " Quake Mode : "
+	-- 	},
+	-- 	quake_switch
+	-- },
+
 	Gtk.Box {
 		orientation = 'HORIZONTAL',
 		homogeneous = true,
@@ -43,7 +45,7 @@ content = Gtk.Box {
 			label = "Apply",
 			on_clicked = function ()
 				conf.moonterm.interpreter = entry_interpreter.text
-				conf.moonterm.quake_mode = quake_switch:get_active()
+				-- conf.moonterm.quake_mode = quake_switch:get_active()
 				inifile:save(('%s/moonterm.ini'):format(dir), conf)
 				dialog_config:hide()
 			end
@@ -56,6 +58,6 @@ content = Gtk.Box {
 	}
 }
 
+-- quake_switch:set_active(conf.moonterm.quake_mode)
 dialog_config:get_content_area():append(content)
 entry_interpreter:grab_focus()
-quake_switch:set_active(conf.moonterm.quake_mode)

--- a/src/moonterm-dialog.lua
+++ b/src/moonterm-dialog.lua
@@ -2,13 +2,14 @@
  @package   MoonTerm
  @filename  moonterm-dialog.lua
  @version   1.0
- @author    Diaz Urbaneja Victor Diego Alejandro <sodomon2@gmail.com>
+ @author    Diaz Urbaneja Victor Diego Alejandro <sodomon.dev@gmail.com>
  @date      17.01.2021 00:52:45 -04
 --]]
 
 dialog_config = Gtk.Dialog {
 	title = "Preferences",
-	resizable = false
+	resizable = false,
+	hide_on_close = true
 }
 
 entry_interpreter = Gtk.Entry()

--- a/src/moonterm-dialog.lua
+++ b/src/moonterm-dialog.lua
@@ -11,30 +11,27 @@ dialog_config = Gtk.Dialog {
 	resizable = false
 }
 
+entry_interpreter = Gtk.Entry()
+quake_switch = Gtk.Switch()
+
 content = Gtk.Box {
 	orientation = 'VERTICAL',
 	spacing = 5,
-	border_width = 5,
 	Gtk.Box {
 		orientation = 'HORIZONTAL',
 		Gtk.Label {
 			label = " Interpreter : ",
 			use_markup = true,
 		},
-		Gtk.Entry {
-			id = 'entry_interpreter'
-		}
+		entry_interpreter
 	},
 	Gtk.Box {
 		orientation = 'HORIZONTAL',
 		spacing = 5,
-		border_width = 5,
 		Gtk.Label {
 			label = " Quake Mode : "
 		},
-		Gtk.Switch {
-			id = 'quake_switch'
-		}
+		quake_switch
 	},
 	Gtk.Box {
 		orientation = 'HORIZONTAL',
@@ -44,8 +41,8 @@ content = Gtk.Box {
 			id = 'btn_apply',
 			label = "Apply",
 			on_clicked = function ()
-				conf.moonterm.interpreter = content.child.entry_interpreter.text
-				conf.moonterm.quake_mode = content.child.quake_switch:get_active()
+				conf.moonterm.interpreter = entry_interpreter.text
+				conf.moonterm.quake_mode = quake_switch:get_active()
 				inifile:save(('%s/moonterm.ini'):format(dir), conf)
 				dialog_config:hide()
 			end
@@ -58,6 +55,6 @@ content = Gtk.Box {
 	}
 }
 
-dialog_config:get_content_area():add(content)
-content.child.entry_interpreter:grab_focus()
-content.child.quake_switch:set_active(conf.moonterm.quake_mode)
+dialog_config:get_content_area():append(content)
+entry_interpreter:grab_focus()
+quake_switch:set_active(conf.moonterm.quake_mode)

--- a/src/moonterm-keybinds.lua
+++ b/src/moonterm-keybinds.lua
@@ -15,22 +15,22 @@ function toggle_fullscreen()
 	end
 end
 
-function quake()
-	if conf.moonterm.quake_mode == true then
-		visible = not visible
-		if visible then
-			main_window:show_all()
-			main_window.skip_taskbar_hint = true
-		else
-			main_window:hide()
-			main_window.skip_taskbar_hint = false
-		end
-	end
-end
+-- function quake()
+-- 	if conf.moonterm.quake_mode == true then
+-- 		visible = not visible
+-- 		if visible then
+-- 			main_window:show_all()
+-- 			main_window.skip_taskbar_hint = true
+-- 		else
+-- 			main_window:hide()
+-- 			main_window.skip_taskbar_hint = false
+-- 		end
+-- 	end
+-- end
 
-if conf.moonterm.quake_mode == true then
-	Keybinder.bind("F12",quake)
-end
+-- if conf.moonterm.quake_mode == true then
+-- 	Keybinder.bind("F12",quake)
+-- end
 
 keybindings = {
 	-- alphanumeric keys

--- a/src/moonterm-keybinds.lua
+++ b/src/moonterm-keybinds.lua
@@ -45,18 +45,25 @@ keybindings = {
 	}
 }
 
-function main_window:on_key_press_event(event)
-	local ctrl_on = event.state.CONTROL_MASK
-	local shift_on = event.state.SHIFT_MASK
-	alphanumeric_keys = keybindings[1][event.keyval]
-	function_keys = keybindings[2][event.keyval]
+local event_controller = Gtk.EventControllerKey.new()
+event_controller:set_propagation_phase(Gtk.PropagationPhase.CAPTURE)
+main_window:add_controller(event_controller)
 
-	if ( alphanumeric_keys and shift_on and ctrl_on ) then
+function event_controller:on_key_pressed(keyval, keycode, state)
+	local ctrl_on = state.CONTROL_MASK or false
+	local shift_on = state.SHIFT_MASK or false
+	
+	local alphanumeric_keys = keybindings[1][keyval]
+	local function_keys = keybindings[2][keyval]
+	
+	if (alphanumeric_keys and shift_on and ctrl_on) then
 		alphanumeric_keys()
-	elseif ( function_keys and not shift_on and not ctrl_on ) then
+		return true
+	elseif (function_keys and not shift_on and not ctrl_on) then
 		function_keys()
-	else
-		return false
+		return true
 	end
-	return true
+	
+	return false
 end
+

--- a/src/moonterm-menu.lua
+++ b/src/moonterm-menu.lua
@@ -2,64 +2,134 @@
  @package   MoonTerm
  @filename  moonterm-menu.lua
  @version   1.0
- @autor     Diaz Urbaneja Victor Diego Alejandro <sodomon2@gmail.com>
+ @autor     Diaz Urbaneja Victor Diego Alejandro <sodomon.dev@gmail.com>
  @date      30.01.2021 19:54:09 -04
 ]]
 
-function main_window:on_button_press_event(event)	
-	if (event.type == 'BUTTON_PRESS' and event.button == 3) then
-		menu = Gtk.Menu {
-			Gtk.ImageMenuItem {
-				label = "Copy",
-				image = Gtk.Image {
-					stock = "gtk-copy"
-				},
-				on_activate = function()
-					term:copy_clipboard()
-				end
-			},
-			Gtk.ImageMenuItem {
-				label = "Paste",
-				image = Gtk.Image {
-					stock = "gtk-paste"
-				},
-				on_activate = function()
-					term:paste_clipboard()
-				end
-			},
-			Gtk.SeparatorMenuItem {},
-			Gtk.ImageMenuItem {
-				label = "About Moonterm",
-				image = Gtk.Image {
-					stock = "gtk-about"
-				},
-				on_activate = function()
-					about_window:run()
-					about_window:hide()
-				end
-			},
-			Gtk.ImageMenuItem {
-				label = "Preferences",
-				image = Gtk.Image {
-					stock = "gtk-preferences"
-				},
-				on_activate = function()
-					dialog_config:show_all()
-				end
-			},
-			Gtk.SeparatorMenuItem {},
-			Gtk.ImageMenuItem {
-				label = "Quit",
-				image = Gtk.Image {
-					stock = "gtk-quit"
-				},
-				on_activate = function()
-					app:quit()
-				end
-			}
-		}
-		menu:attach_to_widget(main_window, null)
-		menu:show_all()
-		menu:popup(nil, nil, nil, event.button, event.time)
+local gesture_click = Gtk.GestureClick()
+gesture_click:set_button(Gdk.BUTTON_SECONDARY)
+main_window:add_controller(gesture_click)
+
+local context_menu = Gtk.Popover()
+context_menu:set_parent(main_window)
+context_menu:set_has_arrow(false)
+
+local function create_menu_button(icon_name, label_text, action_callback)
+	local button = Gtk.Button()
+	button:add_css_class("flat")
+	
+	local box = Gtk.Box {
+		orientation = Gtk.Orientation.HORIZONTAL,
+		spacing = 4,
+		margin_start = 4,
+		margin_end = 4,
+		margin_top = 4,
+		margin_bottom = 4
+	}
+	
+	local icon = Gtk.Image.new_from_icon_name(icon_name)
+	icon:set_icon_size(Gtk.IconSize.NORMAL)
+	
+	local label = Gtk.Label {
+		label = label_text,
+		xalign = 0
+	}
+	
+	box:append(icon)
+	box:append(label)
+	button:set_child(box)
+	
+	if action_callback then
+		function button:on_clicked()
+			action_callback()
+		end
 	end
+	
+	return button
+end
+
+local menu_box = Gtk.Box {
+	orientation = Gtk.Orientation.VERTICAL,
+	spacing = 0,
+	margin_top = 4,
+	margin_bottom = 4,
+	margin_start = 4,
+	margin_end = 4
+}
+
+local copy_button = create_menu_button(
+	"gtk-copy",
+	"Copy",
+	function()
+		term:copy_clipboard()
+		context_menu:popdown()
+	end
+)
+
+local paste_button = create_menu_button(
+	"gtk-paste",
+	"Paste",
+	function()
+		term:paste_clipboard()
+		context_menu:popdown()
+	end
+)
+
+local separator1 = Gtk.Separator {
+	orientation = Gtk.Orientation.HORIZONTAL,
+	margin_top = 4,
+	margin_bottom = 4
+}
+
+local preferences_button = create_menu_button(
+	"gtk-preferences",
+	"Preferences",
+	function()
+		dialog_config:show()
+		context_menu:popdown()
+	end
+)
+
+local about_button = create_menu_button(
+	"gtk-about",
+	"About Moonterm",
+	function()
+		about_window:show()
+		context_menu:popdown()
+	end
+)
+
+local separator2 = Gtk.Separator {
+	orientation = Gtk.Orientation.HORIZONTAL,
+	margin_top = 4,
+	margin_bottom = 4
+}
+
+local quit_button = create_menu_button(
+	"application-exit",
+	"Quit",
+	function()
+		app:quit()
+	end
+)
+
+menu_box:append(copy_button)
+menu_box:append(paste_button)
+menu_box:append(separator1)
+menu_box:append(preferences_button)
+menu_box:append(about_button)
+menu_box:append(separator2)
+menu_box:append(quit_button)
+
+context_menu:set_child(menu_box)
+
+function gesture_click:on_released(n_press, x, y, data)
+	local pointing_rect = Gdk.Rectangle()
+	pointing_rect.x = math.floor(x - 100)
+	pointing_rect.y = math.floor(y)
+	pointing_rect.width = 1
+	pointing_rect.height = 1
+
+	context_menu:set_pointing_to(pointing_rect)
+	context_menu:popup()
 end


### PR DESCRIPTION
Completely migrated from Gtk3 to Gtk4, achieving true compatibility with Wayland without compromising X11.

- Quake Mode removed due to the deprecation of keybinder and lack of Wayland support (I may resume support for Quake Mode in the future). see 6942204afcfabe1ed79cf09f0be67b8e935e8416
- New popover menu; the old GtkMenuItem was deprecated in Gtk4, so its alternative is now PopoverMenu. see 3dae26f773490a2c9c3e2c417ebf985c8508e020
- Gtk, Gdk, and Vte updated to support gtk4. dd2b3e1f808190009fce18eaca989e1b3c7f4ac3